### PR TITLE
Fixed width format

### DIFF
--- a/tablib/core.py
+++ b/tablib/core.py
@@ -174,7 +174,7 @@ class Dataset(object):
             self.title = None
 
         self._register_formats()
-        self.fields_width = ''
+        self.fields_width = set()
 
 
     def __len__(self):

--- a/tablib/core.py
+++ b/tablib/core.py
@@ -174,6 +174,7 @@ class Dataset(object):
             self.title = None
 
         self._register_formats()
+        self.fields_width = ''
 
 
     def __len__(self):
@@ -556,6 +557,21 @@ class Dataset(object):
         headers have been set, they will be used as table headers.
 
         ..notice:: This method can be used for export only.
+        """
+        pass
+
+    @property
+    def fix():
+        """A Fixed width representation of the :class:`Dataset` object.
+
+        A dataset object can also be imported by setting the :class:`Dataset.fix` attribute: ::
+        but you have to set fields_width with a python struct format
+
+            data = tablib.Dataset(headers=['age', 'first_name', 'last_name')
+            data.fields_width = '2s 4s 5s'
+            data.fix = '90JohnAdams'
+
+        Then you can export this to json
         """
         pass
 

--- a/tablib/core.py
+++ b/tablib/core.py
@@ -568,7 +568,7 @@ class Dataset(object):
         but you have to set fields_width with a python struct format
 
             data = tablib.Dataset(headers=['age', 'first_name', 'last_name')
-            data.fields_width = '2s 4s 5s'
+            data.fields_width = (2, 4, 5)
             data.fix = '90JohnAdams'
 
         Then you can export this to json

--- a/tablib/formats/__init__.py
+++ b/tablib/formats/__init__.py
@@ -11,5 +11,6 @@ from . import _tsv as tsv
 from . import _html as html
 from . import _xlsx as xlsx
 from . import _ods as ods
+from . import _fix as fix
 
-available = (json, xls, yaml, csv, tsv, html, xlsx, ods)
+available = (json, xls, yaml, csv, tsv, html, xlsx, ods, fix)

--- a/tablib/formats/_fix.py
+++ b/tablib/formats/_fix.py
@@ -18,6 +18,10 @@ def check_fields_width(dset):
         raise Exception('You have to define fields_width to Dataset')
 
 
+def make_struct(sizes):
+    return Struct(' '.join(['%ss' % s for s in sizes]))
+
+
 def export_set(dataset):
     lines = []
     for idx, row in enumerate(dataset._package(dicts=False)):
@@ -32,7 +36,7 @@ def export_set(dataset):
 
 def import_set(dset, in_stream, headers=True):
     """Returns dataset from CSV stream."""
-
-    fixed_struct = Struct(dset.fields_width)
+    dset.wipe()
+    fixed_struct = make_struct(dset.fields_width)
     for row in in_stream.splitlines():
-        dset.extend([fixed_struct.unpack(row)])
+        dset.append([x.strip() for x in fixed_struct.unpack(row)])

--- a/tablib/formats/_fix.py
+++ b/tablib/formats/_fix.py
@@ -19,7 +19,15 @@ def check_fields_width(dset):
 
 
 def export_set(dataset):
-    pass
+    lines = []
+    for idx, row in enumerate(dataset._package(dicts=False)):
+        if dataset.headers and idx == 0:
+            continue
+        lines.append(
+            ''.join([str(x).ljust(y)
+                     for x, y in zip(row, dataset.fields_width)])
+        )
+    return '\n'.join(lines)
 
 
 def import_set(dset, in_stream, headers=True):

--- a/tablib/formats/_fix.py
+++ b/tablib/formats/_fix.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+""" Tablib - Fixed Width Support.
+"""
+
+from struct import Struct
+
+
+title = 'fix'
+extensions = ('fix',)
+
+
+DEFAULT_ENCODING = 'utf-8'
+
+
+def check_fields_width(dset):
+    if not hasattr(dset, 'fields_width'):
+        raise Exception('You have to define fields_width to Dataset')
+
+
+def export_set(dataset):
+    pass
+
+
+def import_set(dset, in_stream, headers=True):
+    """Returns dataset from CSV stream."""
+
+    fixed_struct = Struct(dset.fields_width)
+    for row in in_stream.splitlines():
+        dset.extend([fixed_struct.unpack(row)])

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -305,6 +305,20 @@ class TablibTestCase(unittest.TestCase):
 
         self.assertEqual(html, d.html)
 
+    def test_fix_export(self):
+        """Verify exporting dataset object as Fixed width data."""
+
+        fixed_data = ''
+        dimensions = (6, 10, 2)
+        self.founders.fields_width = dimensions
+        for founder in self.founders:
+            for col, width in zip(founder, dimensions):
+                fixed_data += str(col).ljust(width)
+            fixed_data += '\n'
+        fixed_data = fixed_data.strip()
+
+        self.assertEqual(fixed_data, self.founders.fix)
+
 
     def test_unicode_append(self):
         """Passes in a single unicode character and exports."""
@@ -400,6 +414,19 @@ class TablibTestCase(unittest.TestCase):
         data.csv = _csv
 
         self.assertEqual(_csv, data.csv)
+
+    def test_fix_import(self):
+        """Generate and import Fixed width."""
+        data.append(self.john)
+        data.append(self.george)
+        data.headers = self.headers
+        data.fields_width = (6, 10, 2)
+
+        _fix = data.fix
+
+        data.fix = _fix
+
+        self.assertEqual(_fix, data.fix)
 
 
     def test_csv_import_set_with_spaces(self):


### PR DESCRIPTION
This is a first try. It's only an idea I'm working and I'm wondering if it would be useful. It's related to parse fixed width data files, and then export to other formats.

For now I'm using [struct](http://docs.python.org/2/library/struct.html) and only as a string. If you want to get a float or integer you can use [`add_formater`](http://docs.python-tablib.org/en/latest/api/)

Any suggestions?

I've been added the tests.