### PR TITLE
CSV custom delimiter support

### DIFF
--- a/tablib/core.py
+++ b/tablib/core.py
@@ -256,6 +256,8 @@ class Dataset(object):
                     setattr(cls, fmt.title, property(fmt.export_set, fmt.import_set))
                 except AttributeError:
                     setattr(cls, fmt.title, property(fmt.export_set))
+                setattr(cls, 'set_%s' % fmt.title, fmt.import_set)
+                setattr(cls, 'get_%s' % fmt.title, fmt.export_set)
 
             except AttributeError:
                 pass

--- a/tablib/formats/_csv.py
+++ b/tablib/formats/_csv.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-""" Tablib - CSV Support.
+""" Tablib - *SV Support.
 """
 
 from tablib.compat import is_py3, csv, StringIO
@@ -11,17 +11,17 @@ extensions = ('csv',)
 
 
 DEFAULT_ENCODING = 'utf-8'
+DEFAULT_DELIMITER = ','
 
 
-
-def export_set(dataset):
+def export_set(dataset, delimiter=DEFAULT_DELIMITER):
     """Returns CSV representation of Dataset."""
     stream = StringIO()
 
     if is_py3:
-        _csv = csv.writer(stream)
+        _csv = csv.writer(stream, delimiter=delimiter)
     else:
-        _csv = csv.writer(stream, encoding=DEFAULT_ENCODING)
+        _csv = csv.writer(stream, delimiter=delimiter, encoding=DEFAULT_ENCODING)
 
     for row in dataset._package(dicts=False):
         _csv.writerow(row)
@@ -29,15 +29,15 @@ def export_set(dataset):
     return stream.getvalue()
 
 
-def import_set(dset, in_stream, headers=True):
+def import_set(dset, in_stream, headers=True, delimiter=DEFAULT_DELIMITER):
     """Returns dataset from CSV stream."""
 
     dset.wipe()
 
     if is_py3:
-        rows = csv.reader(in_stream.splitlines())
+        rows = csv.reader(in_stream.splitlines(), delimiter=delimiter)
     else:
-        rows = csv.reader(in_stream.splitlines(), encoding=DEFAULT_ENCODING)
+        rows = csv.reader(in_stream.splitlines(), delimiter=delimiter, encoding=DEFAULT_ENCODING)
     for i, row in enumerate(rows):
 
         if (i == 0) and (headers):
@@ -46,10 +46,10 @@ def import_set(dset, in_stream, headers=True):
             dset.append(row)
 
 
-def detect(stream):
+def detect(stream, delimiter=DEFAULT_DELIMITER):
     """Returns True if given stream is valid CSV."""
     try:
-        csv.Sniffer().sniff(stream, delimiters=',')
+        csv.Sniffer().sniff(stream, delimiters=delimiter)
         return True
     except (csv.Error, TypeError):
         return False

--- a/tablib/formats/_tsv.py
+++ b/tablib/formats/_tsv.py
@@ -3,57 +3,28 @@
 """ Tablib - TSV (Tab Separated Values) Support.
 """
 
-from tablib.compat import is_py3, csv, StringIO
-
-
+from tablib.formats._csv import (
+    export_set as export_set_wrapper,
+    import_set as import_set_wrapper,
+    detect as detect_wrapper,
+)
 
 title = 'tsv'
 extensions = ('tsv',)
 
 DEFAULT_ENCODING = 'utf-8'
+DELIMITER = '\t'
 
 def export_set(dataset):
-    """Returns a TSV representation of Dataset."""
-
-    stream = StringIO()
-
-    if is_py3:
-        _tsv = csv.writer(stream, delimiter='\t')
-    else:
-        _tsv = csv.writer(stream, encoding=DEFAULT_ENCODING, delimiter='\t')
-
-    for row in dataset._package(dicts=False):
-        _tsv.writerow(row)
-
-    return stream.getvalue()
+    """Returns TSV representation of Dataset."""
+    return export_set_wrapper(dataset, delimiter=DELIMITER)
 
 
 def import_set(dset, in_stream, headers=True):
     """Returns dataset from TSV stream."""
-
-    dset.wipe()
-
-    if is_py3:
-        rows = csv.reader(in_stream.splitlines(), delimiter='\t')
-    else:
-        rows = csv.reader(in_stream.splitlines(), delimiter='\t',
-                          encoding=DEFAULT_ENCODING)
-
-    for i, row in enumerate(rows):
-        # Skip empty rows
-        if not row:
-            continue
-
-        if (i == 0) and (headers):
-            dset.headers = row
-        else:
-            dset.append(row)
+    return import_set_wrapper(dset, in_stream, headers=headers, delimiter=DELIMITER)
 
 
 def detect(stream):
     """Returns True if given stream is valid TSV."""
-    try:
-        csv.Sniffer().sniff(stream, delimiters='\t')
-        return True
-    except (csv.Error, TypeError):
-        return False
+    return detect_wrapper(stream, delimiter=DELIMITER)

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -401,6 +401,17 @@ class TablibTestCase(unittest.TestCase):
 
         self.assertEqual(_csv, data.csv)
 
+    def test_csv_import_set_semicolons(self):
+        """Test for proper output with semicolon separated CSV."""
+        data.append(self.john)
+        data.append(self.george)
+        data.headers = self.headers
+
+        _csv = data.get_csv(delimiter=';')
+
+        data.set_csv(_csv, delimiter=';')
+
+        self.assertEqual(_csv, data.get_csv(delimiter=';'))
 
     def test_csv_import_set_with_spaces(self):
         """Generate and import CSV set serialization when row values have
@@ -414,6 +425,19 @@ class TablibTestCase(unittest.TestCase):
         data.csv = _csv
 
         self.assertEqual(_csv, data.csv)
+
+    def test_csv_import_set_semicolon_with_spaces(self):
+        """Generate and import semicolon separated CSV set serialization when row values have
+        spaces."""
+        data.append(('Bill Gates', 'Microsoft'))
+        data.append(('Steve Jobs', 'Apple'))
+        data.headers = ('Name', 'Company')
+
+        _csv = data.get_csv(delimiter=';')
+
+        data.set_csv(_csv, delimiter=';')
+
+        self.assertEqual(_csv, data.get_csv(delimiter=';'))
 
 
     def test_tsv_import_set(self):


### PR DESCRIPTION
CSV and TSV are very similar formats. Some people need tab separated values, some (me) need `;`-separated values.
So I've come up with the idea of having one interface for all kinds of \*SV formats (delimited by any character you need).
The idea is to keep csv and tsv format in the Dataset class and also add functions `set_*` and `get_*` (e.g. `set_csv`, `get_csv`) which allow to use custom arguments (you can't do it with a property). In my case I've added `delimiter` argument.

There are also two testcases showing how to use it. Other tests also pass, so hopefully I haven't broken anything :-).

Please tell me what you think. Is this idea OK? As I said just need `;`-separated values support, but maybe someone else will need `:` or `^` or anything-else-separated values support in the future. Perhaps there is a better way to provide it, but I haven't figured out anything better.