### PR TITLE
Fixed a compatibility bug for Python 3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Patches and Suggestions
 - Marc Abramowitz
 - Alex Gaynor
 - James Douglass
+- Tommy Anthony

--- a/tablib/compat.py
+++ b/tablib/compat.py
@@ -37,6 +37,7 @@ if is_py3:
     unicode = str
     bytes = bytes
     basestring = str
+    xrange = range
 
 else:
     from cStringIO import StringIO as BytesIO
@@ -53,3 +54,4 @@ else:
     import tablib.packages.dbfpy as dbfpy
 
     unicode = unicode
+    xrange = xrange

--- a/tablib/formats/_xls.py
+++ b/tablib/formats/_xls.py
@@ -5,7 +5,7 @@
 
 import sys
 
-from tablib.compat import BytesIO, xlwt, xlrd, XLRDError
+from tablib.compat import BytesIO, xlwt, xlrd, XLRDError, xrange
 import tablib
 
 title = 'xls'


### PR DESCRIPTION
Fixed a compatibility bug for Python 3 by adding xrange to compat.py.

The code in tablib/formats/_xls.py used xrange in parsing excel spreadsheets.
xrange is not a builtin for Python 3, so I've added

    xrange = range

in compat.py and imported it in tablib/formats/_xls.py.

To verify the fix:

    headers = ('first_name', 'last_name')

    data = [
        ('John', 'Adams'),
        ('George', 'Washington')
    ]

    data = tablib.Dataset(*data, headers=headers)
    new = tablib.Dataset()
    new.xls = data.xls

Produces the error:

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/tablib/formats/_xls.py", line 78, in import_set
        for i in xrange(sheet.nrows):
    NameError: name 'xrange' is not defined