### PR TITLE
Replace tabs with whitespaces

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ Patches and Suggestions
 - Alex Gaynor
 - James Douglass
 - Tommy Anthony
+- Marco Dallagiacoma

--- a/tablib/formats/_html.py
+++ b/tablib/formats/_html.py
@@ -23,45 +23,45 @@ extensions = ('html', )
 
 
 def export_set(dataset):
-	"""HTML representation of a Dataset."""
+    """HTML representation of a Dataset."""
 
-	stream = StringIO()
+    stream = StringIO()
 
-	page = markup.page()
-	page.table.open()
+    page = markup.page()
+    page.table.open()
 
-	if dataset.headers is not None:
-		new_header = [item if item is not None else '' for item in dataset.headers] 
+    if dataset.headers is not None:
+        new_header = [item if item is not None else '' for item in dataset.headers] 
 
-		page.thead.open()
-		headers = markup.oneliner.th(new_header)
-		page.tr(headers)
-		page.thead.close()
+        page.thead.open()
+        headers = markup.oneliner.th(new_header)
+        page.tr(headers)
+        page.thead.close()
 
-	for row in dataset:
-		new_row = [item if item is not None else '' for item in row] 
+    for row in dataset:
+        new_row = [item if item is not None else '' for item in row] 
 
-		html_row = markup.oneliner.td(new_row)
-		page.tr(html_row)
+        html_row = markup.oneliner.td(new_row)
+        page.tr(html_row)
 
-	page.table.close()
+    page.table.close()
 
     # Allow unicode characters in output
-	wrapper = codecs.getwriter("utf8")(stream)
-	wrapper.writelines(unicode(page))
+    wrapper = codecs.getwriter("utf8")(stream)
+    wrapper.writelines(unicode(page))
 
-	return stream.getvalue().decode('utf-8')
+    return stream.getvalue().decode('utf-8')
 
 
 def export_book(databook):
-	"""HTML representation of a Databook."""
+    """HTML representation of a Databook."""
 
-	stream = StringIO()
+    stream = StringIO()
 
-	for i, dset in enumerate(databook._datasets):
-		title = (dset.title if dset.title else 'Set %s' % (i))
-		stream.write('<%s>%s</%s>\n' % (BOOK_ENDINGS, title, BOOK_ENDINGS))
-		stream.write(dset.html)
-		stream.write('\n')
+    for i, dset in enumerate(databook._datasets):
+        title = (dset.title if dset.title else 'Set %s' % (i))
+        stream.write('<%s>%s</%s>\n' % (BOOK_ENDINGS, title, BOOK_ENDINGS))
+        stream.write(dset.html)
+        stream.write('\n')
 
-	return stream.getvalue()
+    return stream.getvalue()


### PR DESCRIPTION
According to pep8, spaces should be used to indent code [0].
The file formats/_html , unlike all the other files, is indented with tabs.
This pull request replaces tabs with spaces in that file.

[0] https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces