### PR TITLE
Small documentation fix in Dataset class

### DIFF
--- a/tablib/core.py
+++ b/tablib/core.py
@@ -349,7 +349,7 @@ class Dataset(object):
         A dataset object can also be imported by setting the `Dataset.dict` attribute: ::
 
             data = tablib.Dataset()
-            data.json = '[{"last_name": "Adams","age": 90,"first_name": "John"}]'
+            data.dict = [{'age': 90, 'first_name': 'Kenneth', 'last_name': 'Reitz'}]
 
         """
         return self._package()


### PR DESCRIPTION
Typo in Dataset documentation manifesting itself in a confusing code example on the rtd's page:

https://tablib.readthedocs.org/en/latest/api/#tablib.Dataset.dict

````python
data = tablib.Dataset()
data.json = '[{"last_name": "Adams","age": 90,"first_name": "John"}]'
````