### PR TITLE
Fix export only formats

### DIFF
--- a/tablib/core.py
+++ b/tablib/core.py
@@ -252,12 +252,13 @@ class Dataset(object):
             try:
                 try:
                     setattr(cls, fmt.title, property(fmt.export_set, fmt.import_set))
+                    setattr(cls, 'get_%s' % fmt.title, fmt.export_set)
+                    setattr(cls, 'set_%s' % fmt.title, fmt.import_set)
                     cls._formats[fmt.title] = (fmt.export_set, fmt.import_set)
                 except AttributeError:
                     setattr(cls, fmt.title, property(fmt.export_set))
+                    setattr(cls, 'get_%s' % fmt.title, fmt.export_set)
                     cls._formats[fmt.title] = (fmt.export_set, None)
-                setattr(cls, 'get_%s' % fmt.title, fmt.export_set)
-                setattr(cls, 'set_%s' % fmt.title, fmt.import_set)
 
             except AttributeError:
                 cls._formats[fmt.title] = (None, None)


### PR DESCRIPTION
Formats like LaTeX could have never been exported because
`setattr(cls, set_%s % fmt.title, fmt.import_set)` always failed
for export-only formats and with that the exception was caught in the
outer try/except and the format tuple was set to (None, None) with
`cls._formats[fmt.title] = (None, None)`