### PR TITLE
Fixed textual representation for Dataset with no headers

### DIFF
--- a/tablib/core.py
+++ b/tablib/core.py
@@ -223,7 +223,8 @@ class Dataset(object):
         result = []
 
         # Add unicode representation of headers.
-        result.append([unicode(h) for h in self.__headers])
+        if self.__headers:
+            result.append([unicode(h) for h in self.__headers])
 
         # Add unicode representation of rows.
         result.extend(list(map(unicode, row)) for row in self._data)
@@ -232,7 +233,8 @@ class Dataset(object):
         field_lens = list(map(max, zip(*lens)))
 
         # delimiter between header and data
-        result.insert(1, ['-' * length for length in field_lens])
+        if self.__headers:
+            result.insert(1, ['-' * length for length in field_lens])
 
         format_string = '|'.join('{%s:%s}' % item for item in enumerate(field_lens))
 

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -351,6 +351,16 @@ class TablibTestCase(unittest.TestCase):
         self.assertFalse('^' in output)
         self.assertTrue('textasciicircum' in output)
 
+    def test_str_no_columns(self):
+        d = tablib.Dataset(['a', 1], ['b', 2], ['c', 3])
+        output = '%s' % d
+
+        self.assertEqual(output.splitlines(), [
+            'a|1',
+            'b|2',
+            'c|3'
+        ])
+
     def test_unicode_append(self):
         """Passes in a single unicode character and exports."""
 


### PR DESCRIPTION
If a `Dataset` does not have any headers, then it is not printable:

    >>> data = tablib.Dataset(['a', 1], ['b', 2], ['c', 3])
    >>> print data
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File ".../tablib/core.py", line 242, in __str__
        return self.__unicode__()
      File ".../tablib/core.py", line 226, in __unicode__
        result.append([unicode(h) for h in self.__headers])
    TypeError: 'NoneType' object is not iterable

This change resolves this, using a string representation of the dataset, without headers:

    >>> data = tablib.Dataset(['a', 1], ['b', 2], ['c', 3])
    >>> print data
    a|1
    b|2
    c|3