### PR TITLE
Add HTML format to the book_export test and fix the format to work properly

### DIFF
--- a/tablib/formats/_html.py
+++ b/tablib/formats/_html.py
@@ -31,7 +31,7 @@ def export_set(dataset):
     page.table.open()
 
     if dataset.headers is not None:
-        new_header = [item if item is not None else '' for item in dataset.headers] 
+        new_header = [item if item is not None else '' for item in dataset.headers]
 
         page.thead.open()
         headers = markup.oneliner.th(new_header)
@@ -39,7 +39,7 @@ def export_set(dataset):
         page.thead.close()
 
     for row in dataset:
-        new_row = [item if item is not None else '' for item in row] 
+        new_row = [item if item is not None else '' for item in row]
 
         html_row = markup.oneliner.td(new_row)
         page.tr(html_row)
@@ -58,10 +58,13 @@ def export_book(databook):
 
     stream = StringIO()
 
+    # Allow unicode characters in output
+    wrapper = codecs.getwriter("utf8")(stream)
+
     for i, dset in enumerate(databook._datasets):
         title = (dset.title if dset.title else 'Set %s' % (i))
-        stream.write('<%s>%s</%s>\n' % (BOOK_ENDINGS, title, BOOK_ENDINGS))
-        stream.write(dset.html)
-        stream.write('\n')
+        wrapper.write('<%s>%s</%s>\n' % (BOOK_ENDINGS, title, BOOK_ENDINGS))
+        wrapper.write(dset.html)
+        wrapper.write('\n')
 
-    return stream.getvalue()
+    return stream.getvalue().decode('utf-8')

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -392,6 +392,7 @@ class TablibTestCase(unittest.TestCase):
         book.xls
         book.xlsx
         book.ods
+        book.html
 
     def test_json_import_set(self):
         """Generate and import JSON set serialization."""


### PR DESCRIPTION
The export_book method in the _html.py format file was not being called by tests.  Adding it causes this error:

```
ERROR: test_book_export_no_exceptions (__main__.TablibTestCase)
Test that various exports don't error out.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_tablib.py", line 395, in test_book_export_no_exceptions
    book.html
  File "/home/vagrant/development/tablib/tablib/formats/_html.py", line 63, in export_book
    stream.write('<%s>%s</%s>\n' % (BOOK_ENDINGS, title, BOOK_ENDINGS))
TypeError: 'str' does not support the buffer interface
```

This PR also fixes that error largely by copying the way that export_set method does.