### PR TITLE
Fix #260 date and datetime export to JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ junit-py27.xml
 
 # tox noise
 .tox
+
+# pyenv noise
+.python-version

--- a/tablib/formats/_json.py
+++ b/tablib/formats/_json.py
@@ -5,8 +5,10 @@
 
 import tablib
 
-import sys
-from tablib.packages import omnijson as json
+try:
+    import json
+except ImportError:
+    from tablib.packages import omnijson as json
 
 
 title = 'json'

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -6,6 +6,9 @@ import json
 import unittest
 import sys
 import os
+
+import datetime
+
 import tablib
 from tablib.compat import markup, unicode, is_py3
 from tablib.core import Row
@@ -368,6 +371,26 @@ class TablibTestCase(unittest.TestCase):
             new_row = ('å', 'é')
         else:
             exec ("new_row = (u'å', u'é')")
+
+        data.append(new_row)
+
+        data.json
+        data.yaml
+        data.csv
+        data.tsv
+        data.xls
+        data.xlsx
+        data.ods
+        data.html
+        data.latex
+
+    def test_datetime_append(self):
+        """Passes in a single datetime and a single date and exports."""
+
+        new_row = (
+            datetime.datetime.now(),
+            datetime.datetime.today(),
+        )
 
         data.append(new_row)
 


### PR DESCRIPTION
Fix date and datetime export to JSON in Python versions with a json package

Python without a json package will use omnijson and fail on date and datetime objects.
Added unit tests.