### PR TITLE
Remove LOCALE from str regular expression

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ Patches and Suggestions
 - Marco Dallagiacoma
 - Mathias Loesch
 - Tushar Makkar
+- Andrii Soldatenko

--- a/tablib/packages/xlwt/ExcelFormulaLexer.py
+++ b/tablib/packages/xlwt/ExcelFormulaLexer.py
@@ -4,7 +4,7 @@ import sys
 from antlr import EOF, CommonToken as Tok, TokenStream, TokenStreamException
 import struct
 import ExcelFormulaParser
-from re import compile as recompile, match, LOCALE, UNICODE, IGNORECASE, VERBOSE
+from re import compile as recompile, match, UNICODE, IGNORECASE, VERBOSE
 
 
 int_const_pattern = r"\d+\b"
@@ -51,7 +51,7 @@ pattern_type_tuples = (
 
 _re = recompile(
     '(' + ')|('.join([i[0] for i in pattern_type_tuples]) + ')',
-    VERBOSE+LOCALE+IGNORECASE)
+    VERBOSE+IGNORECASE)
 
 _toktype = [None] + [i[1] for i in pattern_type_tuples]
 # need dummy at start because re.MatchObject.lastindex counts from 1

--- a/tablib/packages/xlwt3/ExcelFormulaLexer.py
+++ b/tablib/packages/xlwt3/ExcelFormulaLexer.py
@@ -2,7 +2,7 @@ import sys
 from .antlr import EOF, CommonToken as Tok, TokenStream, TokenStreamException
 import struct
 from . import ExcelFormulaParser
-from re import compile as recompile, match, LOCALE, UNICODE, IGNORECASE, VERBOSE
+from re import compile as recompile, match, UNICODE, IGNORECASE, VERBOSE
 
 
 int_const_pattern = r"\d+\b"
@@ -49,7 +49,7 @@ pattern_type_tuples = (
 
 _re = recompile(
     '(' + ')|('.join([i[0] for i in pattern_type_tuples]) + ')',
-    VERBOSE+LOCALE+IGNORECASE)
+    VERBOSE+IGNORECASE)
 
 _toktype = [None] + [i[1] for i in pattern_type_tuples]
 # need dummy at start because re.MatchObject.lastindex counts from 1

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py26, py27, py32, py33, py34, py35, pypy
 
 [testenv]
 commands = python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, pypy
+envlist = py26, py27, py32, py33, py34, py35, py36, pypy
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
Similar issue https://github.com/python-excel/xlwt/issues/90
similar patch https://github.com/python-excel/xlwt/pull/91

```
GLOB sdist-make: /home/vagrant/ethoos_platform/tablib/setup.py
py26 inst-nodeps: /home/vagrant/ethoos_platform/tablib/.tox/dist/tablib-0.11.3.zip
py26 installed: DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6,argparse==1.4.0,py==1.4.32,pytest==3.0.5,tablib==0.11.3
py26 runtests: PYTHONHASHSEED='447426207'
py26 runtests: commands[0] | python setup.py test
=============================================================================================== test session starts ================================================================================================
platform linux3 -- Python 2.6.9, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /home/vagrant/ethoos_platform/tablib, inifile:
collected 63 items

test_tablib.py ...............................................................

============================================================================================ 63 passed in 0.28 seconds =============================================================================================
py27 inst-nodeps: /home/vagrant/ethoos_platform/tablib/.tox/dist/tablib-0.11.3.zip
py27 installed: py==1.4.32,pytest==3.0.5,tablib==0.11.3
py27 runtests: PYTHONHASHSEED='447426207'
py27 runtests: commands[0] | python setup.py test
=============================================================================================== test session starts ================================================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /home/vagrant/ethoos_platform/tablib, inifile:
collected 63 items

test_tablib.py ...............................................................
py34 inst-nodeps: /home/vagrant/ethoos_platform/tablib/.tox/dist/tablib-0.11.3.zip
py34 installed: py==1.4.32,pytest==3.0.5,tablib==0.11.3
py34 runtests: PYTHONHASHSEED='447426207'
py34 runtests: commands[0] | python setup.py test
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.4.5, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /home/vagrant/ethoos_platform/tablib, inifile:
collected 63 items

test_tablib.py ...............................................................

============================================================================================ 63 passed in 0.28 seconds =============================================================================================
py35 inst-nodeps: /home/vagrant/ethoos_platform/tablib/.tox/dist/tablib-0.11.3.zip
py35 installed: py==1.4.32,pytest==3.0.5,tablib==0.11.3
py35 runtests: PYTHONHASHSEED='447426207'
py35 runtests: commands[0] | python setup.py test
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.5.0, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /home/vagrant/ethoos_platform/tablib, inifile:
collected 63 items

test_tablib.py ...............................................................
============================================================================================ 63 passed in 0.28 seconds =============================================================================================
py36 create: /home/vagrant/ethoos_platform/tablib/.tox/py36
py36 installdeps: pytest
py36 inst: /home/vagrant/ethoos_platform/tablib/.tox/dist/tablib-0.11.3.zip
py36 installed: py==1.4.32,pytest==3.0.5,tablib==0.11.3
py36 runtests: PYTHONHASHSEED='447426207'
py36 runtests: commands[0] | python setup.py test
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.6.0rc2, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /home/vagrant/ethoos_platform/tablib, inifile:
collected 63 items

test_tablib.py ...............................................................
```