### PR TITLE
Fixed classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     url='http://python-tablib.org',
     packages=packages,
     license='MIT',
-    classifiers=(
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Natural Language :: English',
@@ -87,6 +87,8 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
-    ),
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
     tests_require=['pytest'],
 )


### PR DESCRIPTION
moved classifiers from tuple to list(this allow to use `setup.py upload` command in python >= 3.5)
added python 3.5 and 3.6 to classifiers list