### PR TITLE
fix python interpreter supported version in doc

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -77,11 +77,12 @@ Pythons Supported
 
 At this time, the following Python platforms are officially supported:
 
-* cPython 2.5
 * cPython 2.6
 * cPython 2.7
-* cPython 3.1
-* cPython 3.2
+* cPython 3.3
+* cPython 3.4
+* cPython 3.5
+* cPython 3.6
 * PyPy-c 1.4
 * PyPy-c 1.5
 


### PR DESCRIPTION
This merge requests changes supported version as written in the documentation to reflects python interpreter version used in *tox.ini* for unit tests.