### PR TITLE
Switched format and stream arguments in import_book call to Databook.load

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ Patches and Suggestions
 - Rabin Nankhwa
 - Marco Dallagiacoma
 - Mathias Loesch
+- Jorik Booij

--- a/tablib/core.py
+++ b/tablib/core.py
@@ -1153,7 +1153,7 @@ def import_set(stream, format=None, **kwargs):
 def import_book(stream, format=None, **kwargs):
     """Return dataset of given stream."""
 
-    return Databook().load(stream, format, **kwargs)
+    return Databook().load(format, stream, **kwargs)
 
 
 class InvalidDatasetType(Exception):


### PR DESCRIPTION
The arguments (stream and format) in the Databook.load call from import_book are in the wrong order. This causes Databook.load to always throw an UnsupportedFormat exception.

Could also be fixed by switching the arguments on Databook.load, but that might break more existing code.