### PR TITLE
fix(): remove openpyxl warning by properly accessing cells

### DIFF
--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -119,7 +119,7 @@ def dset_sheet(dataset, ws, freeze_panes=True):
         row_number = i + 1
         for j, col in enumerate(row):
             col_idx = get_column_letter(j + 1)
-            cell = ws.cell('%s%s' % (col_idx, row_number))
+            cell = ws['%s%s' % (col_idx, row_number)]
 
             # bold headers
             if (row_number == 1) and dataset.headers:


### PR DESCRIPTION
see there https://bitbucket.org/openpyxl/openpyxl/src/0f8537998f95c9d8d44913c2edb367516b799d4a/openpyxl/worksheet/worksheet.py?at=default&fileviewer=file-view-default#worksheet.py-303

Raising warning in production :(