### PR TITLE
Delegate type coercion to openpyxl

### DIFF
--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -120,33 +120,29 @@ def dset_sheet(dataset, ws, freeze_panes=True):
             if (row_number == 1) and dataset.headers:
                 # ws.cell('%s%s'%(col_idx, row_number)).value = unicode(
                     # '%s' % col, errors='ignore')
-                ws.cell('%s%s'%(col_idx, row_number)).value = unicode(col)
                 style = ws.get_style('%s%s' % (col_idx, row_number))
                 style.font.bold = True
                 if freeze_panes:
                     # As already done in #53, but after Merge lost:
                     #  Export Freeze only after first Line
                     ws.freeze_panes = 'A2'
-                    
+
             # bold separators
             elif len(row) < dataset.width:
-                ws.cell('%s%s'%(col_idx, row_number)).value = unicode(
-                    '%s' % col, errors='ignore')
                 style = ws.get_style('%s%s' % (col_idx, row_number))
                 style.font.bold = True
 
             # wrap the rest
             else:
                 try:
-                    if '\n' in col:
-                        ws.cell('%s%s'%(col_idx, row_number)).value = unicode(
-                            '%s' % col, errors='ignore')
+                    str_col_value = unicode(col)
+                except TypeError:
+                    str_col_value = ''
+
+                    if '\n' in str_col_value:
                         style = ws.get_style('%s%s' % (col_idx, row_number))
                         style.alignment.wrap_text
-                    else:
-                        ws.cell('%s%s'%(col_idx, row_number)).value = unicode(
-                            '%s' % col, errors='ignore')
-                except TypeError:
-                    ws.cell('%s%s'%(col_idx, row_number)).value = unicode(col)
+
+            ws.cell('%s%s' % (col_idx, row_number)).value = col
 
 

--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -17,6 +17,7 @@ import tablib
 Workbook = openpyxl.workbook.Workbook
 ExcelWriter = openpyxl.writer.excel.ExcelWriter
 get_column_letter = openpyxl.cell.get_column_letter
+DataTypeException = openpyxl.shared.exc.DataTypeException
 
 from tablib.compat import unicode
 
@@ -143,6 +144,7 @@ def dset_sheet(dataset, ws, freeze_panes=True):
                         style = ws.get_style('%s%s' % (col_idx, row_number))
                         style.alignment.wrap_text
 
-            ws.cell('%s%s' % (col_idx, row_number)).value = col
-
-
+            try:
+                ws.cell('%s%s' % (col_idx, row_number)).value = col
+            except (ValueError, TypeError, DataTypeException):
+                ws.cell('%s%s' % (col_idx, row_number)).value = unicode(col)


### PR DESCRIPTION
First of all, thank you for the great job on tablib, it helps a lot in our day to day job.

On my company we were having problems with the format of the columns exported on the format xlsx.

At the time of debug #252 seemed to be somewhat related with the problem we were observing (numeric fields appearing as text values and preventing spreadsheet app sums etc without a previous conversion inside the spreadsheet app ) so I decided to investigate a bit more. It seems that the default conversion of unicode of all the col values prevents openpyxl to detect the type of the value correctly, ending up treating all the values as text.

My initial approach, as presented in this pr for discussion, delegates the type detection and conversion to openpyxl, which seems like a sensible approach to me. (for what I've seen tablib already puts most of the export logic for xlsx on openpyxl's side). It fallsback to converting the value to unicode, and pass it again to openpyxl, if any data related conversion exception is raised (keeping compatibility, lowering the risk for existing codebases). 

I also noticed that no tests exist for this particular feature and I'am open to doing them (if there isn't any blocker already detected to doing them).

If this seems sensible I can proceed with some polishing (and maybe doing it for xls) and tests so it can be merged.

