### PR TITLE
ujson presence no longer breaks tablib (resolves #297)

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -40,16 +40,6 @@ To download the full source history from Git, see :ref:`Source Control <scm>`.
 .. _zipball: http://github.com/kennethreitz/tablib/zipball/master
 
 
-.. _speed-extensions:
-Speed Extensions
-----------------
-
-You can gain some speed improvement by optionally installing the ujson_ library.
-Tablib will fallback to the standard `json` module if it doesn't find ``ujson``.
-
-.. _ujson: https://pypi.python.org/pypi/ujson
-
-
 .. _updates:
 Staying Updated
 ---------------

--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,6 @@ if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     sys.exit()
 
-if sys.argv[-1] == 'speedups':
-    try:
-        __import__('pip')
-    except ImportError:
-        print('Pip required.')
-        sys.exit(1)
-
-    os.system('pip install ujson')
-    sys.exit()
 
 if sys.argv[-1] == 'test':
     try:

--- a/tablib/formats/_json.py
+++ b/tablib/formats/_json.py
@@ -3,13 +3,10 @@
 """ Tablib - JSON Support
 """
 import decimal
+import json
 
 import tablib
 
-try:
-    import ujson as json
-except ImportError:
-    import json
 
 title = 'json'
 extensions = ('json', 'jsn')
@@ -22,7 +19,6 @@ def date_handler(obj):
         return obj.isoformat()
     else:
         return obj
-    # return obj.isoformat() if hasattr(obj, 'isoformat') else obj
 
 
 def export_set(dataset):


### PR DESCRIPTION
It seems to me like ujson support was broken from the day 1.
Fixing it would require recursively going through the structure and swapping datetime objects for `.isoformat()` equivalents, which would be surely slower than leaving it to cpython `json` library.
