### PR TITLE
Changes the way to get a cell from a xlsx file

### DIFF
--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -119,7 +119,7 @@ def dset_sheet(dataset, ws, freeze_panes=True):
         row_number = i + 1
         for j, col in enumerate(row):
             col_idx = get_column_letter(j + 1)
-            cell = ws.cell('%s%s' % (col_idx, row_number))
+            cell = ws['%s%s' % (col_idx, row_number)]
 
             # bold headers
             if (row_number == 1) and dataset.headers:


### PR DESCRIPTION
Relates to issues #324 and #324

Solves the exception `cell() takes at least 3 arguments (2 given)` when exporting to .xlsx