### PR TITLE
Fix: Circular reference detected error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,3 +34,4 @@ Patches and Suggestions
 - Mathias Loesch
 - Tushar Makkar
 - Andrii Soldatenko
+- Bruno Soares

--- a/tablib/formats/_json.py
+++ b/tablib/formats/_json.py
@@ -15,24 +15,23 @@ title = 'json'
 extensions = ('json', 'jsn')
 
 
-def date_handler(obj):
+def serialize_objects_handler(obj):
     if isinstance(obj, decimal.Decimal):
         return str(obj)
     elif hasattr(obj, 'isoformat'):
         return obj.isoformat()
     else:
         return obj
-    # return obj.isoformat() if hasattr(obj, 'isoformat') else obj
 
 
 def export_set(dataset):
     """Returns JSON representation of Dataset."""
-    return json.dumps(dataset.dict, default=date_handler)
+    return json.dumps(dataset.dict, default=serialize_objects_handler)
 
 
 def export_book(databook):
     """Returns JSON representation of Databook."""
-    return json.dumps(databook._package(), default=date_handler)
+    return json.dumps(databook._package(), default=serialize_objects_handler)
 
 
 def import_set(dset, in_stream):

--- a/tablib/formats/_json.py
+++ b/tablib/formats/_json.py
@@ -3,6 +3,7 @@
 """ Tablib - JSON Support
 """
 import decimal
+from uuid import UUID
 
 import tablib
 
@@ -16,7 +17,7 @@ extensions = ('json', 'jsn')
 
 
 def serialize_objects_handler(obj):
-    if isinstance(obj, decimal.Decimal):
+    if isinstance(obj, decimal.Decimal) or isinstance(obj, UUID):
         return str(obj)
     elif hasattr(obj, 'isoformat'):
         return obj.isoformat()

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -5,6 +5,7 @@
 import json
 import unittest
 import sys
+from uuid import uuid4
 
 import datetime
 
@@ -225,6 +226,22 @@ class TablibTestCase(unittest.TestCase):
 
         # Delete from invalid index
         self.assertRaises(IndexError, self.founders.__delitem__, 3)
+            
+    def test_json_export(self):
+        """Verify exporting dataset object as JSON"""
+        
+        address_id = uuid4()
+        headers = self.headers + ('address_id',)
+        founders = tablib.Dataset(headers=headers, title='Founders')
+        founders.append(('John', 'Adams', 90, address_id))
+        founders_json = founders.export('json')
+        
+        expected_json = (
+            '[{"first_name": "John", "last_name": "Adams", "gpa": 90, '
+            '"address_id": "%s"}]' % str(address_id)
+        )
+        
+        self.assertEqual(founders_json, expected_json)
 
     def test_csv_export(self):
         """Verify exporting dataset object as CSV."""


### PR DESCRIPTION
### Problem
I got the error `ValueError: Circular reference detected` when trying to get a [Record instance representation](https://github.com/kennethreitz/records/blob/v0.5.2/records.py#L45) of records lib.

### Solution
My table has a uuid type field. This type is not JSON serializable, so needs to be handled (converted to str).

Maybe this fix https://github.com/kennethreitz/records/issues/95.

### Error scenario
Create database with a uuid field
```sql
create table bar (                                                      
    id serial primary key,
    foo_id uuid
);
```
Insert data
```sql
insert into bar (foo_id) values ('30fcb0c7-a836-446c-9c88-411800c0c818')
```
Use records lib and get the error
```python
In [1]: import records
In [2]: db = records.Database('postgres://...')
In [3]: rows = db.query('select * from bar')
In [4]: rows[0]
...
ValueError: Circular reference detected
``` 