### PR TITLE
Updated xlsx format to remove reference to openpyxl's deprecated get_active_worksheet

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -289,6 +289,14 @@ Now that we have extra meta-data on our rows, we can easily filter our :class:`D
 
 It's that simple. The original :class:`Dataset` is untouched.
 
+Open an Excel Workbook and read first sheet
+--------------------------------
+
+To open an Excel 2007 and later workbook with a single sheet (or a workbook with multiple sheets but you just want the first sheet), use the following:
+
+data = tablib.Dataset()
+data.xlsx = open('my_excel_file.xlsx', 'rb').read()
+print(data)
 
 Excel Workbook With Multiple Sheets
 ------------------------------------

--- a/tablib/core.py
+++ b/tablib/core.py
@@ -526,9 +526,9 @@ class Dataset(object):
 
         Import assumes (for now) that headers exist.
 
-        .. admonition:: Binary Warning
+        .. admonition:: Binary Warning for Python 2
 
-             :class:`Dataset.csv` uses \\r\\n line endings by default, so make
+             :class:`Dataset.csv` uses \\r\\n line endings by default so, in Python 2, make
              sure to write in binary mode::
 
                  with open('output.csv', 'wb') as f:
@@ -536,6 +536,18 @@ class Dataset(object):
 
              If you do not do this, and you export the file on Windows, your
              CSV file will open in Excel with a blank line between each row.
+
+        .. admonition:: Line endings for Python 3
+
+             :class:`Dataset.csv` uses \\r\\n line endings by default so, in Python 3, make
+             sure to include newline='' otherwise you will get a blank line between each row 
+             when you open the file in Excel::
+
+                 with open('output.csv', 'w', newline='') as f:
+                     f.write(data.csv)
+
+             If you do not do this, and you export the file on Windows, your
+             CSV file will open in Excel with a blank line between each row.             
         """
         pass
 

--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -71,7 +71,7 @@ def import_set(dset, in_stream, headers=True):
     dset.wipe()
 
     xls_book = openpyxl.reader.excel.load_workbook(BytesIO(in_stream))
-    sheet = xls_book.get_active_sheet()
+    sheet = xls_book.active
 
     dset.title = sheet.title
 


### PR DESCRIPTION
Code now uses Openpyxl's .active property as per http://openpyxl.readthedocs.io/en/2.5/_modules/openpyxl/workbook/workbook.html#Workbook.get_active_sheet

Added instructions on opening a .xlsx file to the Tutorial.

Added instructions on exporting .csv on Windows in Python 3