### PR TITLE
Removed 2.6 and 3.3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
 install:
   - pip install -r requirements.txt
 script: python test_tablib.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
+  - 3.7-dev
 install:
   - pip install -r requirements.txt
 script: python test_tablib.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7-dev
 install:
   - pip install -r requirements.txt
 script: python test_tablib.py

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, pypy
+envlist = py27, py34, py35, py36, py37, pypy
 
 [testenv]
 commands = python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
- synchronize travis and tox by removing 2.6 (openpyxl no longer supports 2.6)
- drop support for 3.3 ([end of life was 9-29-2017](https://www.python.org/dev/peps/pep-0398/#id11))