### PR TITLE
Added stream to CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ junit-py27.xml
 
 # pyenv noise
 .python-version
+tablib.egg-info/*

--- a/tablib/formats/_csv.py
+++ b/tablib/formats/_csv.py
@@ -13,8 +13,8 @@ extensions = ('csv',)
 DEFAULT_DELIMITER = unicode(',')
 
 
-def export_set(dataset, **kwargs):
-    """Returns CSV representation of Dataset."""
+def export_stream_set(dataset, **kwargs):
+    """Returns CSV representation of Dataset as file-like."""
     stream = StringIO()
 
     kwargs.setdefault('delimiter', DEFAULT_DELIMITER)
@@ -24,6 +24,13 @@ def export_set(dataset, **kwargs):
     for row in dataset._package(dicts=False):
         _csv.writerow(row)
 
+    stream.seek(0)
+    return stream
+
+
+def export_set(dataset, **kwargs):
+    """Returns CSV representation of Dataset."""
+    stream = export_stream_set(dataset, **kwargs)
     return stream.getvalue()
 
 

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import tablib
 from tablib.compat import markup, unicode, is_py3
 from tablib.core import Row
-from tablib.formats import csv as csv_format
+from tablib.formats import _csv as csv_module
 
 
 class TablibTestCase(unittest.TestCase):
@@ -261,6 +261,24 @@ class TablibTestCase(unittest.TestCase):
             csv = csv.strip(',') + '\r\n'
 
         self.assertEqual(csv, self.founders.csv)
+
+    def test_csv_stream_export(self):
+        """Verify exporting dataset object as CSV from file object."""
+
+        # Build up the csv string with headers first, followed by each row
+        csv = ''
+        for col in self.headers:
+            csv += col + ','
+
+        csv = csv.strip(',') + '\r\n'
+
+        for founder in self.founders:
+            for col in founder:
+                csv += str(col) + ','
+            csv = csv.strip(',') + '\r\n'
+
+        csv_stream = csv_module.export_stream_set(self.founders)
+        self.assertEqual(csv, csv_stream.getvalue())
 
     def test_tsv_export(self):
         """Verify exporting dataset object as TSV."""


### PR DESCRIPTION
Hello
Here's a proof of concept of what I talk in #207 .
This PR just add the possibility to get a stream or its content.
I didn't change the API, just added `seek(0)`, to have a file ready to use.

I use the same code here https://github.com/django-import-export/django-import-export/pull/821/files#diff-9c335e3895cab39c4af9e510b328c2f0R157
It's a Django app for import/export from DB.

To have a good integration we need to get file-like object.