### PR TITLE
Handle case where there is an empty line in CSV

### DIFF
--- a/tablib/formats/_csv.py
+++ b/tablib/formats/_csv.py
@@ -44,7 +44,7 @@ def import_set(dset, in_stream, headers=True, **kwargs):
 
         if (i == 0) and (headers):
             dset.headers = row
-        else:
+        elif row:
             dset.append(row)
 
 


### PR DESCRIPTION
Fixes #334

Python's csv module considers CSVs with empty lines to be valid (as `csv.Sniffer().sniff` is successful). However, this causes print() on Dataset to fail (specifically line `field_lens = list(map(max, zip(*lens)))` in `__unicode__()` in `tablib/core.py`).

I have modified the code to ignore empty lines, so that all rows in the Dataset have equal number of columns.

Existing unit tests passed.