### PR TITLE
Replace a deprecated method call

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,4 @@ Patches and Suggestions
 - Tushar Makkar
 - Andrii Soldatenko
 - Bruno Soares
+- Tsuyoshi Hombashi

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ packages = [
 
 install = [
     'odfpy',
-    'openpyxl',
+    'openpyxl>=2.4.0',
     'unicodecsv',
     'xlrd',
     'xlwt',

--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -52,7 +52,7 @@ def export_book(databook, freeze_panes=True):
 
     wb = Workbook()
     for sheet in wb.worksheets:
-        wb.remove_sheet(sheet)
+        wb.remove(sheet)
     for i, dset in enumerate(databook._datasets):
         ws = wb.create_sheet()
         ws.title = dset.title if dset.title else 'Sheet%s' % (i)


### PR DESCRIPTION
I got the following `DeprecationWarning` when I run `tablib` tests in Python 3.7:

    tablib/formats/_xlsx.py:55: DeprecationWarning: Call to deprecated function remove_sheet (Use wb.remove(worksheet) or del wb[sheetname]).

Looks like `Workbook.remove_sheet` method deprecated since `openpyxl 2.4.0` (released at 2016-09-15).
