### PR TITLE
Include pandas dependency when testing with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,8 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
+minversion = 2.4
 envlist = py27, py34, py35, py36, pypy
 
 [testenv]
-commands = python setup.py test
 deps = pytest
+extras = pandas
+commands = python setup.py test


### PR DESCRIPTION
Allows all tests to pass.

As pandas is defined as an 'extra', use tox's 'extras' feature. This
requires tox 2.4+, so document that as well.

https://tox.readthedocs.io/en/latest/config.html#conf-extras