### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -1,10 +1,10 @@
-Where possible, please follow PEP8 with regard to coding style. Sometimes the line 
+Where possible, please follow PEP8 with regard to coding style. Sometimes the line
 length restriction is too hard to follow, so don't bend over backwards there.
 
 Triple-quotes should always be """, single quotes are ' unless using "
 would result in less escaping within the string.
 
-All modules, functions, and methods should be well documented reStructuredText for 
+All modules, functions, and methods should be well documented reStructuredText for
 Sphinx AutoDoc.
 
 All functionality should be available in pure Python. Optional C (via Cython)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -254,4 +254,3 @@ History
 * Export Support for XLS, JSON, YAML, and CSV.
 * DataBook Export for XLS, JSON, and YAML.
 * Python Dict Property Support.
-

--- a/docs/_themes/LICENSE
+++ b/docs/_themes/LICENSE
@@ -1,9 +1,9 @@
-Modifications: 
+Modifications:
 
 Copyright (c) 2011 Kenneth Reitz.
 
 
-Original Project: 
+Original Project:
 
 Copyright (c) 2010 by Armin Ronacher.
 

--- a/docs/_themes/README.rst
+++ b/docs/_themes/README.rst
@@ -1,7 +1,7 @@
 krTheme Sphinx Style
 ====================
 
-This repository contains sphinx styles Kenneth Reitz uses in most of 
+This repository contains sphinx styles Kenneth Reitz uses in most of
 his projects. It is a drivative of Mitsuhiko's themes for Flask and Flask related
 projects.  To use this style in your Sphinx documentation, follow
 this guide:
@@ -22,4 +22,3 @@ The following themes exist:
 
 **kr_small**
 	small one-page theme.  Intended to be used by very small addon libraries.
-

--- a/docs/_themes/kr/theme.conf
+++ b/docs/_themes/kr/theme.conf
@@ -4,4 +4,4 @@ stylesheet = flasky.css
 pygments_style = flask_theme_support.FlaskyStyle
 
 [options]
-touch_icon = 
+touch_icon =

--- a/docs/_themes/kr_small/static/flasky.css_t
+++ b/docs/_themes/kr_small/static/flasky.css_t
@@ -8,11 +8,11 @@
  * :license: BSD, see LICENSE for details.
  *
  */
- 
+
 @import url("basic.css");
- 
+
 /* -- page layout ----------------------------------------------------------- */
- 
+
 body {
     font-family: 'Georgia', serif;
     font-size: 17px;
@@ -35,7 +35,7 @@ div.bodywrapper {
 hr {
     border: 1px solid #B1B4B6;
 }
- 
+
 div.body {
     background-color: #ffffff;
     color: #3E4349;
@@ -46,7 +46,7 @@ img.floatingflask {
     padding: 0 0 10px 10px;
     float: right;
 }
- 
+
 div.footer {
     text-align: right;
     color: #888;
@@ -55,12 +55,12 @@ div.footer {
     width: 650px;
     margin: 0 auto 40px auto;
 }
- 
+
 div.footer a {
     color: #888;
     text-decoration: underline;
 }
- 
+
 div.related {
     line-height: 32px;
     color: #888;
@@ -69,18 +69,18 @@ div.related {
 div.related ul {
     padding: 0 0 0 10px;
 }
- 
+
 div.related a {
     color: #444;
 }
- 
+
 /* -- body styles ----------------------------------------------------------- */
- 
+
 a {
     color: #004B6B;
     text-decoration: underline;
 }
- 
+
 a:hover {
     color: #6D4100;
     text-decoration: underline;
@@ -89,7 +89,7 @@ a:hover {
 div.body {
     padding-bottom: 40px; /* saved for footer */
 }
- 
+
 div.body h1,
 div.body h2,
 div.body h3,
@@ -109,24 +109,24 @@ div.indexwrapper h1 {
     height: {{ theme_index_logo_height }};
 }
 {% endif %}
- 
+
 div.body h2 { font-size: 180%; }
 div.body h3 { font-size: 150%; }
 div.body h4 { font-size: 130%; }
 div.body h5 { font-size: 100%; }
 div.body h6 { font-size: 100%; }
- 
+
 a.headerlink {
     color: white;
     padding: 0 4px;
     text-decoration: none;
 }
- 
+
 a.headerlink:hover {
     color: #444;
     background: #eaeaea;
 }
- 
+
 div.body p, div.body dd, div.body li {
     line-height: 1.4em;
 }
@@ -164,25 +164,25 @@ div.note {
     background-color: #eee;
     border: 1px solid #ccc;
 }
- 
+
 div.seealso {
     background-color: #ffc;
     border: 1px solid #ff6;
 }
- 
+
 div.topic {
     background-color: #eee;
 }
- 
+
 div.warning {
     background-color: #ffe4e4;
     border: 1px solid #f66;
 }
- 
+
 p.admonition-title {
     display: inline;
 }
- 
+
 p.admonition-title:after {
     content: ":";
 }
@@ -254,7 +254,7 @@ dl {
 dl dd {
     margin-left: 30px;
 }
- 
+
 pre {
     padding: 0;
     margin: 15px -30px;

--- a/tablib/__init__.py
+++ b/tablib/__init__.py
@@ -5,4 +5,3 @@ from tablib.core import (
     InvalidDatasetType, InvalidDimensions, UnsupportedFormat,
     __version__
 )
-

--- a/tablib/core.py
+++ b/tablib/core.py
@@ -541,14 +541,14 @@ class Dataset(object):
         .. admonition:: Line endings for Python 3
 
              :class:`Dataset.csv` uses \\r\\n line endings by default so, in Python 3, make
-             sure to include newline='' otherwise you will get a blank line between each row 
+             sure to include newline='' otherwise you will get a blank line between each row
              when you open the file in Excel::
 
                  with open('output.csv', 'w', newline='') as f:
                      f.write(data.csv)
 
              If you do not do this, and you export the file on Windows, your
-             CSV file will open in Excel with a blank line between each row.             
+             CSV file will open in Excel with a blank line between each row.
         """
         pass
 

--- a/tablib/formats/_dbf.py
+++ b/tablib/formats/_dbf.py
@@ -89,6 +89,3 @@ def detect(stream):
         # When unpacking a string argument with less than 8 chars, struct.error is
         # raised.
         return False
-
-
-

--- a/tablib/formats/_xls.py
+++ b/tablib/formats/_xls.py
@@ -25,7 +25,7 @@ def detect(stream):
         xlrd.open_workbook(file_contents=stream)
         return True
     except (TypeError, XLRDError):
-        pass 
+        pass
     try:
         xlrd.open_workbook(file_contents=stream.read())
         return True

--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -129,7 +129,7 @@ def dset_sheet(dataset, ws, freeze_panes=True):
                 if freeze_panes:
                     #  Export Freeze only after first Line
                     ws.freeze_panes = 'A2'
-                    
+
             # bold separators
             elif len(row) < dataset.width:
                 cell.value = unicode('%s' % col, errors='ignore')
@@ -145,5 +145,3 @@ def dset_sheet(dataset, ws, freeze_panes=True):
                         cell.value = unicode('%s' % col, errors='ignore')
                 except TypeError:
                     cell.value = unicode(col)
-
-

--- a/tablib/packages/dbfpy3/record.py
+++ b/tablib/packages/dbfpy3/record.py
@@ -220,7 +220,7 @@ class DbfRecord(object):
     def toString(self):
         """Return string packed record values."""
 #        for (_def, _dat) in zip(self.dbf.header.fields, self.fieldData):
-#            
+#
 
         return "".join([" *"[self.deleted]] + [
            _def.encodeValue(_dat)

--- a/tablib/packages/markup3.py
+++ b/tablib/packages/markup3.py
@@ -33,7 +33,7 @@ class element:
             self.tag = tag.lower( )
         else:
             self.tag = tag.upper( )
-    
+
     def __call__( self, *args, **kwargs ):
         if len( args ) > 1:
             raise ArgumentError( self.tag )
@@ -42,14 +42,14 @@ class element:
         if self.parent is not None and self.parent.class_ is not None:
             if 'class_' not in kwargs:
                 kwargs['class_'] = self.parent.class_
-            
+
         if self.parent is None and len( args ) == 1:
             x = [ self.render( self.tag, False, myarg, mydict ) for myarg, mydict in _argsdicts( args, kwargs ) ]
             return '\n'.join( x )
         elif self.parent is None and len( args ) == 0:
             x = [ self.render( self.tag, True, myarg, mydict ) for myarg, mydict in _argsdicts( args, kwargs ) ]
             return '\n'.join( x )
-            
+
         if self.tag in self.parent.twotags:
             for myarg, mydict in _argsdicts( args, kwargs ):
                 self.render( self.tag, False, myarg, mydict )
@@ -63,7 +63,7 @@ class element:
             raise DeprecationError( self.tag )
         else:
             raise InvalidElementError( self.tag, self.parent.mode )
-    
+
     def render( self, tag, single, between, kwargs ):
         """Append the actual tags to content."""
 
@@ -89,7 +89,7 @@ class element:
             self.parent.content.append( out )
         else:
             return out
-    
+
     def close( self ):
         """Append a closing tag unless element has only opening tag."""
 
@@ -128,11 +128,11 @@ class page:
                                 these two keyword arguments may be used to select
                                 the set of valid elements in 'xml' mode
                                 invalid elements will raise appropriate exceptions
-        
+
         separator --            string to place between added elements, defaults to newline
-        
+
         class_ --               a class that will be added to every element if defined"""
-        
+
         valid_onetags = [ "AREA", "BASE", "BR", "COL", "FRAME", "HR", "IMG", "INPUT", "LINK", "META", "PARAM" ]
         valid_twotags = [ "A", "ABBR", "ACRONYM", "ADDRESS", "B", "BDO", "BIG", "BLOCKQUOTE", "BODY", "BUTTON",
                 "CAPTION", "CITE", "CODE", "COLGROUP", "DD", "DEL", "DFN", "DIV", "DL", "DT", "EM", "FIELDSET",
@@ -163,7 +163,7 @@ class page:
             self.deptags += list(map( str.lower, self.deptags ))
             self.mode = 'strict_html'
         elif mode == 'loose_html':
-            self.onetags = valid_onetags + deprecated_onetags 
+            self.onetags = valid_onetags + deprecated_onetags
             self.onetags += list(map( str.lower, self.onetags ))
             self.twotags = valid_twotags + deprecated_twotags
             self.twotags += list(map( str.lower, self.twotags ))
@@ -187,12 +187,12 @@ class page:
         return element( attr, case=self.case, parent=self )
 
     def __str__( self ):
-        
+
         if self._full and ( self.mode == 'strict_html' or self.mode == 'loose_html' ):
             end = [ '</body>', '</html>' ]
         else:
             end = [ ]
-        
+
         return self.separator.join( self.header + self.content + self.footer + end )
 
     def __call__( self, escape=False ):
@@ -232,7 +232,7 @@ class page:
 
         lang --     language, usually a two character string, will appear
                     as <html lang='en'> in html mode (ignored in xml mode)
-        
+
         css --      Cascading Style Sheet filename as a string or a list of
                     strings for multiple css files (ignored in xml mode)
 
@@ -306,7 +306,7 @@ class page:
     def css( self, filelist ):
         """This convenience function is only useful for html.
         It adds css stylesheet(s) to the document via the <link> element."""
-      
+
         if isinstance( filelist, str ):
             self.link( href=filelist, rel='stylesheet', type='text/css', media='all' )
         else:
@@ -339,10 +339,10 @@ class _oneliner:
     """An instance of oneliner returns a string corresponding to one element.
     This class can be used to write 'oneliners' that return a string
     immediately so there is no need to instantiate the page class."""
-    
+
     def __init__( self, case='lower' ):
         self.case = case
-    
+
     def __getattr__( self, attr ):
         if attr.startswith("__") and attr.endswith("__"):
             raise AttributeError(attr)
@@ -353,9 +353,9 @@ upper_oneliner = _oneliner( case='upper' )
 
 def _argsdicts( args, mydict ):
     """A utility generator that pads argument list and dictionary values, will only be called with len( args ) = 0, 1."""
-    
+
     if len( args ) == 0:
-        args = None, 
+        args = None,
     elif len( args ) == 1:
         args = _totuple( args[0] )
     else:
@@ -418,7 +418,7 @@ _escape = escape
 
 def unescape( text ):
     """Inverse of escape."""
-    
+
     if isinstance( text, str ):
         if '&amp;' in text:
             text = text.replace( '&amp;', '&' )


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.