### PR TITLE
Unpin transient dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,7 @@
-backports.csv==1.0.6; python_version < '3.0'
-certifi==2017.7.27.1
-chardet==3.0.4
-et-xmlfile==1.0.1
-idna==2.6
-jdcal==1.3
-numpy==1.13.1
-odfpy==1.3.5
-openpyxl==2.4.8
-pandas==0.20.3
-pkginfo==1.4.1
-python-dateutil==2.6.1
-pytz==2017.2
-PyYAML==3.12
-requests==2.18.4
-requests-toolbelt==0.8.0
-six==1.10.0
-tqdm==4.15.0
-unicodecsv==0.14.1
-urllib3==1.22
-xlrd==1.1.0
-xlwt==1.3.0
+backports.csv; python_version < '3.0'
+odfpy
+openpyxl>=2.4.0
+pandas
+pyyaml
+xlrd
+xlwt


### PR DESCRIPTION
The project is expected to work with the all versions of dependencies as
specified by dependency ranges, not just a single pinned version. Stop
overspecifying them.